### PR TITLE
Enable publishing multiple bundles to various risks per track

### DIFF
--- a/.github/workflows/build-bundle.yaml
+++ b/.github/workflows/build-bundle.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Determine branch supported channels
         id: branch-supports-risk
         continue-on-error: true
-        run: grep ${{ matrix.risk }} .supported-risks
+        run: grep ${{ matrix.risk }} main/.supported-charm-risks
           
       - name: Pack Bundle
         id: packed

--- a/.github/workflows/build-bundle.yaml
+++ b/.github/workflows/build-bundle.yaml
@@ -46,11 +46,12 @@ jobs:
 
       - name: Determine branch supported channels
         id: branch-supports-risk
+        continue-on-error: true
         run: grep ${{ matrix.risk }} .supported-risks
           
       - name: Pack Bundle
         id: packed
-        if: ${{ steps.branch-supports-risk.outcome == 'success' }}
+        if: steps.branch-supports-risk.outcome == 'success'
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
           pushd main
@@ -60,8 +61,8 @@ jobs:
           charmcraft pack -v
           echo "BUNDLE_FILE=$(ls ./*.zip)" >> $GITHUB_ENV
       
-      - name: Upload bundle to edge
-        if: ${{ github.event_name == 'push' && steps.packed.outcome == 'success'}}
+      - name: Upload bundle to ${{env.channel}}
+        if: github.event_name == 'push' && steps.packed.outcome == 'success'
         uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           charm-path: main
@@ -70,7 +71,7 @@ jobs:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Upload bundle to edge
-        if: ${{ github.event_name != 'push' && steps.packed.outcome == 'success'}}
+      - name: None Push Event Report
+        if: github.event_name != 'push' && steps.packed.outcome == 'success'
         run: |
             echo "Would upload ${{ env.BUNDLE_FILE }} to ${{ env.channel }}"

--- a/.github/workflows/build-bundle.yaml
+++ b/.github/workflows/build-bundle.yaml
@@ -40,35 +40,18 @@ jobs:
       matrix:
         risk: [edge, beta, candidate, stable]
     env:
+      track: ${{ needs.bundle-track.outputs.track }}
       channel: ${{ needs.bundle-track.outputs.track }}/${{matrix.risk}}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine branch supported channels
-        id: branch-supports-risk
-        continue-on-error: true
-        run: grep ${{ matrix.risk }} main/.supported-charm-risks
-          
       - name: Pack Bundle
         id: packed
-        if: steps.branch-supports-risk.outcome == 'success'
+        continue-on-error: true
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
-          pushd main
-
-          echo "::group::Alter charm channels"
-          yq -e -i '.applications.k8s.channel = "${{env.channel}}"' bundle.yaml
-          yq -e -i '.applications.k8s-worker.channel = "${{env.channel}}"' bundle.yaml
-          echo ""::endgroup::""
-
-          echo "::group::Charm channels before packing"
-          yq '.applications | with_entries(select(.key | test("k8s*"))) | .[].channel' bundle.yaml
-          echo ""::endgroup::""
-
-          echo "::group::Pack Bundle"
-          charmcraft pack -v
-          echo ""::endgroup::""
-          echo "BUNDLE_FILE=$(ls ./*.zip)" >> $GITHUB_ENV
+          ./pack.sh main ${{env.track}} ${{matrix.risk}}
+          echo "BUNDLE_FILE=$(ls .main/*.zip)" >> $GITHUB_ENV
       
       - name: Upload bundle to ${{env.channel}}
         if: github.event_name == 'push' && steps.packed.outcome == 'success'

--- a/.github/workflows/build-bundle.yaml
+++ b/.github/workflows/build-bundle.yaml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         risk: [edge, beta, candidate, stable]
     env:
-      channel: ${{ needs.bundle-track.outputs.track }}/${{matrix.risk}}'
+      channel: ${{ needs.bundle-track.outputs.track }}/${{matrix.risk}}
     steps:
       - uses: actions/checkout@v4
 
@@ -55,10 +55,19 @@ jobs:
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
           pushd main
+
+          echo "::group::Alter charm channels"
           yq -e -i '.applications.k8s.channel = "${{env.channel}}"' bundle.yaml
           yq -e -i '.applications.k8s-worker.channel = "${{env.channel}}"' bundle.yaml
+          echo ""::endgroup::""
+
+          echo "::group::Charm channels before packing"
           yq '.applications | with_entries(select(.key | test("k8s*"))) | .[].channel' bundle.yaml
+          echo ""::endgroup::""
+
+          echo "::group::Pack Bundle"
           charmcraft pack -v
+          echo ""::endgroup::""
           echo "BUNDLE_FILE=$(ls ./*.zip)" >> $GITHUB_ENV
       
       - name: Upload bundle to ${{env.channel}}

--- a/.github/workflows/build-bundle.yaml
+++ b/.github/workflows/build-bundle.yaml
@@ -8,40 +8,67 @@ on:
     branches:
     - main
     - release-*
+  pull_request:
   
 jobs:
-  build-charms:
+  bundle-track:
+    name: Find track from branch
+    runs-on: ubuntu-latest
+    outputs:
+      track: ${{steps.find-track.outputs.TRACK}}
+    steps:
+      - name: Find Track
+        id: find-track
+        env:
+          BRANCH: ${{ github.event.ref }}
+        run: |
+          BRANCH=${BRANCH#refs/heads/}  # strip off refs/heads/ if it exists
+          if [[ "${BRANCH}" == "main" ]]; then
+            echo "TRACK=latest" >> "$GITHUB_OUTPUT"
+          elif [[ "${BRANCH}" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+            echo "TRACK=${BRANCH:8}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error Failed to determine track from branch ${BRANCH}"
+            exit 1
+          fi
+
+  build-bundles:
     name: Build and push bundles
     runs-on: ubuntu-latest
+    needs: bundle-track
+    strategy:
+      matrix:
+        risk: [edge, beta, candidate, stable]
+    env:
+      channel: ${{ needs.bundle-track.outputs.track }}/${{matrix.risk}}'
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Determine Channel
-        env:
-            BRANCH: ${{ github.event.ref }}
-        run: |
-            BRANCH=${BRANCH#refs/heads/}  # strip off refs/heads/ if it exists
-            if [[ "${BRANCH}" == "main" ]]; then
-              echo "CHANNEL=latest/edge" >> "$GITHUB_ENV"
-            elif [[ "${BRANCH}" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
-              echo "CHANNEL=${BRANCH:8}/edge" >> "$GITHUB_ENV"
-            else
-              echo "::error Failed to determine track/risk from branch ${BRANCH}"
-              exit 1
-            fi
-
+      - name: Determine branch supported channels
+        id: branch-supports-risk
+        run: grep ${{ matrix.risk }} .supported-risks
+          
       - name: Pack Bundle
+        id: packed
+        if: ${{ steps.branch-supports-risk.outcome == 'success' }}
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
           pushd main
-          charmcraft pack -v 
+          yq -e -i '.applications.k8s.channel = "${{env.channel}}"' bundle.yaml
+          yq -e -i '.applications.k8s-worker.channel = "${{env.channel}}"' bundle.yaml
+          yq '.applications | with_entries(select(.key | test("k8s*"))) | .[].channel' bundle.yaml
+          charmcraft pack -v
           echo "BUNDLE_FILE=$(ls ./*.zip)" >> $GITHUB_ENV
       
       - name: Upload bundle to edge
+        if: ${{ github.event_name == 'push' && steps.packed.outcome == 'success'}}
         uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           charm-path: main
           built-charm-path: ${{ env.BUNDLE_FILE }}
-          channel: ${{ env.CHANNEL }}
+          channel: ${{env.channel}}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Upload bundle to edge
+        if: ${{ github.event_name != 'push' && steps.packed.outcome == 'success'}}
+        run: |
+            echo "Would upload ${{ env.BUNDLE_FILE }} to ${{ env.channel }}"

--- a/.github/workflows/build-bundle.yaml
+++ b/.github/workflows/build-bundle.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Find Track
         id: find-track
         env:
-          BRANCH: ${{ github.event.ref }}
+          BRANCH: ${{ github.event.ref || github.event.pull_request.base.ref }}
         run: |
           BRANCH=${BRANCH#refs/heads/}  # strip off refs/heads/ if it exists
           if [[ "${BRANCH}" == "main" ]]; then
@@ -42,6 +42,8 @@ jobs:
     env:
       channel: ${{ needs.bundle-track.outputs.track }}/${{matrix.risk}}'
     steps:
+      - uses: actions/checkout@v4
+
       - name: Determine branch supported channels
         id: branch-supports-risk
         run: grep ${{ matrix.risk }} .supported-risks

--- a/.github/workflows/build-bundle.yaml
+++ b/.github/workflows/build-bundle.yaml
@@ -63,7 +63,7 @@ jobs:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: None Push Event Report
+      - name: Push Event Report
         if: github.event_name != 'push' && steps.packed.outcome == 'success'
         run: |
-            echo "Would upload ${{ env.BUNDLE_FILE }} to ${{ env.channel }}"
+            echo "Don't upload ${{ env.BUNDLE_FILE }} to ${{ env.channel }} on push event"

--- a/.supported-risks
+++ b/.supported-risks
@@ -1,2 +1,0 @@
-edge
-beta

--- a/.supported-risks
+++ b/.supported-risks
@@ -1,0 +1,2 @@
+edge
+beta

--- a/pack.sh
+++ b/pack.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+set -eu
+
+bundle=$1
+track=$2
+risk=$3
+
+channel="${track}/${risk}"
+
+pushd ${bundle} > /dev/null
+trap popd EXIT
+
+grep ${risk} .supported-charm-risks
+
+echo "::group::Alter charm channels"
+yq -e -i '.applications.k8s.channel = "'${channel}'"' bundle.yaml
+yq -e -i '.applications.k8s-worker.channel = "'${channel}'"' bundle.yaml
+yq '.applications | with_entries(select(.key | test("k8s*"))) | .[].channel' bundle.yaml
+echo ""::endgroup::""
+
+echo "::group::Pack Bundle"
+charmcraft pack -v
+echo ""::endgroup::""
+


### PR DESCRIPTION
## Overview
Update workflow to support publishing bundles to multiple tracks other than just edge

## Details
With each branch (main / release-1.xx), try to publish the bundle to each risk within that track 
* main -> latest
* release-1.xx -> 1.xx

Naturally, not every track needs every risk.  For instance, `main` should only ever publish to `latest/edge`
Therefore, each branch should contain a `.supported-charm-risks` file in the `main` path.  This will indicate which charm channels are supported.  It's a flat text file whose contents should indicate which charm risks to support, and to which channel this bundle is published.

a bundle with charms 1.30/beta will be published to the 1.30/beta track
a bundle with charms latest/edge will be published to the latest/edge track

When a release branch is ready for a release, simple add to the `.supported-charm-risks` file.



