### PR TITLE
Prepare bundle for 1.31 release -- adjust gh action

### DIFF
--- a/.github/workflows/build-bundle.yaml
+++ b/.github/workflows/build-bundle.yaml
@@ -57,7 +57,7 @@ jobs:
         if: github.event_name == 'push' && steps.packed.outcome == 'success'
         uses: canonical/charming-actions/upload-bundle@2.6.3
         with:
-          bundle-path: ${{ env.BUNDLE_FILE }}
+          bundle-path: ./main
           channel: ${{env.channel}}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Overview
fix-up: The GH actions needs the path to the bundle, not the built bundle