### PR TITLE
Bump machine constraints in TF modules

### DIFF
--- a/terraform/manifest/README.md
+++ b/terraform/manifest/README.md
@@ -71,15 +71,15 @@ a single manifest file similar to the one below:
 
 ``` yaml
 k8s:
-    units: 2
+    units: 3
     base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
-    channel: 1.31/beta
+    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+    channel: latest/edge
 k8s_worker:
-    units: 2
+    units: 3
     base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
-    channel: 1.31/beta
+    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+    channel: latest/edge
 ```
 
 Using the terraform in the above section, the `units`, `base`, `constraints`, and `channel`

--- a/terraform/test/openstack.yaml
+++ b/terraform/test/openstack.yaml
@@ -1,11 +1,13 @@
 k8s:
-    units: 2
+    units: 3
     base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
+    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
     channel: latest/edge
 k8s_worker:
-    units: 2
-    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
+    units: 3
+    base: ubuntu@24.04
+    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+    channel: latest/edge
 openstack_integrator:
     channel: 1.31/stable
     base: ubuntu@22.04

--- a/terraform/test/vanilla.yaml
+++ b/terraform/test/vanilla.yaml
@@ -1,8 +1,10 @@
 k8s:
-    units: 2
+    units: 3
     base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
+    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
     channel: latest/edge
 k8s_worker:
-    units: 2
-    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
+    units: 3
+    base: ubuntu@24.04
+    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+    channel: latest/edge


### PR DESCRIPTION
### Overview
Since these machines templates are being used for actually TF deployments, at least improve the bare configuration to represent a a healthier happier cluster after deployment

### Details
* bump memory to 8G Mem, 16G Disk
* ensure we're using at least `latest/edge` charm versions (until a more suitable stable comes along)
* Use 3 CP machines and 3 Worker machines