### PR TITLE
overlays: Add external load balancer relation to Openstack overlay

### DIFF
--- a/overlays/openstack.yaml
+++ b/overlays/openstack.yaml
@@ -14,3 +14,4 @@ relations:
   - [openstack-cloud-controller:external-cloud-provider, k8s:external-cloud-provider]
   - [openstack-cloud-controller:openstack,               openstack-integrator:clients]
   - [cinder-csi:openstack,                               openstack-integrator:clients]
+  - [k8s:external-load-balancer,                         openstack-integrator:lb-consumers]

--- a/terraform/openstack/integrations.tf
+++ b/terraform/openstack/integrations.tf
@@ -60,3 +60,15 @@ resource "juju_integration" "cinder_csi_kube_control" {
     endpoint  = module.cinder_csi.requires.kube_control
   }
 }
+
+resource "juju_integration" "openstack_external_load_balancer" {
+  model = var.model
+  application {
+    name      = var.k8s.app_name
+    endpoint  = var.k8s.requires.external_load_balancer
+  }
+  application {
+    name      = module.openstack_integrator.app_name
+    endpoint  = module.openstack_integrator.provides.lb_consumers
+  }
+}


### PR DESCRIPTION
### Overview
This PR adds `k8s:external-load-balancer, openstack-integrator:lb-consumers` relation to Openstack overlay.