### PR TITLE
Craft the juju model-config for suppressing fan-config

### DIFF
--- a/.github/workflows/plan-terraform.yaml
+++ b/.github/workflows/plan-terraform.yaml
@@ -20,12 +20,17 @@ jobs:
         - name: Vanilla
           yaml: ./vanilla.yaml
           cloud_integration: ''
+          csi_integration: '[]'
         - name: Openstack
           yaml: ./openstack.yaml
           cloud_integration: openstack
+          csi_integration: '[]'
         - name: Ceph
           yaml: ./ceph.yaml
-          csi_integration: 'ceph'
+          csi_integration: '["ceph"]'
+        - name: Ceph Multiple Clusters
+          yaml: ./ceph.yaml
+          csi_integration: '["ceph", "ceph"]'
     env:
       TF_VAR_branch: ${{ github.head_ref }}
       TF_VAR_manifest_yaml: ${{ matrix.test.yaml }}
@@ -52,7 +57,7 @@ jobs:
         JUJU_CONTROLLER_ADDRESSES="$(juju show-controller | yq '.[$CONTROLLER]'.details.\"api-endpoints\" | tr -d "[]' "|tr -d '"'|tr -d '\n')"
         JUJU_USERNAME="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.user|tr -d '"')"
         JUJU_PASSWORD="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password|tr -d '"')"
-
+        echo "::add-mask::$JUJU_PASSWORD"
         echo "JUJU_CONTROLLER_ADDRESSES=$JUJU_CONTROLLER_ADDRESSES" >> "$GITHUB_ENV"
         echo "JUJU_USERNAME=$JUJU_USERNAME" >> "$GITHUB_ENV"
         echo "JUJU_PASSWORD=$JUJU_PASSWORD" >> "$GITHUB_ENV"
@@ -61,7 +66,6 @@ jobs:
           juju show-controller $(echo $CONTROLLER|tr -d '"') | yq '.[$CONTROLLER]'.details.\"ca-cert\"|tr -d '"'
           echo EOF
         } >> "$GITHUB_ENV"
-
         sed -i "s#ref=[^&\"]*#ref=${{ github.head_ref }}#" ${{env.WORKING_DIR}}/test.tf
     - uses: hashicorp/setup-terraform@v3
     - run: terraform init

--- a/.github/workflows/plan-terraform.yaml
+++ b/.github/workflows/plan-terraform.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         test:
         - name: Vanilla
-          yaml: test/vanilla.yaml
+          yaml: ./vanilla.yaml
           cloud_integration: ''
         - name: Openstack
           yaml: ./openstack.yaml

--- a/.github/workflows/plan-terraform.yaml
+++ b/.github/workflows/plan-terraform.yaml
@@ -21,20 +21,23 @@ jobs:
           yaml: test/vanilla.yaml
           cloud_integration: ''
         - name: Openstack
-          yaml: test/openstack.yaml
+          yaml: ./openstack.yaml
           cloud_integration: openstack
         - name: Ceph
-          yaml: test/ceph.yaml
+          yaml: ./ceph.yaml
           csi_integration: 'ceph'
-          cloud_integration: ''
     env:
-      TF_VAR_model: '{"name": "test", "cloud": "prod-k8s-openstack", "config": {"test": true}}'
+      TF_VAR_branch: ${{ github.head_ref }}
       TF_VAR_manifest_yaml: ${{ matrix.test.yaml }}
       TF_VAR_cloud_integration: ${{ matrix.test.cloud_integration }}
       TF_VAR_csi_integration: ${{ matrix.test.csi_integration }}
-      WORKING_DIR: 'terraform'
+      WORKING_DIR: 'terraform/test'
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        sparse-checkout: ${{env.WORKING_DIR}}
+        sparse-checkout-cone-mode: false
     - name: Install Python
       uses: actions/setup-python@v5
       with:
@@ -58,6 +61,8 @@ jobs:
           juju show-controller $(echo $CONTROLLER|tr -d '"') | yq '.[$CONTROLLER]'.details.\"ca-cert\"|tr -d '"'
           echo EOF
         } >> "$GITHUB_ENV"
+
+        sed -i "s#ref=[^&\"]*#ref=${{ github.head_ref }}#" ${{env.WORKING_DIR}}/test.tf
     - uses: hashicorp/setup-terraform@v3
     - run: terraform init
       working-directory: ${{env.WORKING_DIR}}

--- a/.github/workflows/plan-terraform.yaml
+++ b/.github/workflows/plan-terraform.yaml
@@ -19,14 +19,16 @@ jobs:
         test:
         - name: Vanilla
           yaml: test/vanilla.yaml
+          cloud_integration: ''
         - name: Openstack
           yaml: test/openstack.yaml
           cloud_integration: openstack
         - name: Ceph
           yaml: test/ceph.yaml
           csi_integration: 'ceph'
+          cloud_integration: ''
     env:
-      TF_VAR_model: test
+      TF_VAR_model: '{"name": "test", "cloud": "openstack", "config": {"test": true}}'
       TF_VAR_manifest_yaml: ${{ matrix.test.yaml }}
       TF_VAR_cloud_integration: ${{ matrix.test.cloud_integration }}
       TF_VAR_csi_integration: ${{ matrix.test.csi_integration }}

--- a/.github/workflows/plan-terraform.yaml
+++ b/.github/workflows/plan-terraform.yaml
@@ -28,7 +28,7 @@ jobs:
           csi_integration: 'ceph'
           cloud_integration: ''
     env:
-      TF_VAR_model: '{"name": "test", "cloud": "openstack", "config": {"test": true}}'
+      TF_VAR_model: '{"name": "test", "cloud": "prod-k8s-openstack", "config": {"test": true}}'
       TF_VAR_manifest_yaml: ${{ matrix.test.yaml }}
       TF_VAR_cloud_integration: ${{ matrix.test.cloud_integration }}
       TF_VAR_csi_integration: ${{ matrix.test.csi_integration }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ main/.charmcraft_output_packages.txt
 **/.terraform
 **/.terraform.lock.hcl
 **/*.tfstate
+**/*.tfstate.backup
 **/tfplan

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -9,19 +9,32 @@ charm configuration.
 ## TODO
 - [  ] Set outputs for each charm deployed
 - [  ] Add COS integration
-- [  ] Find a home for this module
-- [  ] Add required subordinate (Landscape, NTP, etc..) see [This private Terraform Plan for details](https://git.launchpad.net/canonical-terraform-modules/tree/services/compute/canonical_k8s_cluster/main.tf#n214)
+- [  ] Add required subordinate (Landscape, NTP, etc..) see [This private Terraform Plan for details][private-details]
 
 ## Applications
 * [k8s](https://charmhub.io/k8s)
 * [k8s-worker](https://charmhub.io/k8s-worker)
 
 ## Inputs
-| Name | Type | Description | Required |
-| - | - | - | - |
-| `manifest_yaml` | string | Absolute path to the manifest yaml for the deployment | True |
-| `model` | string | Name of the Juju model to deploy into | True |
-| `cloud_integration` | string | Selection of a cloud integration | False |
+| Name                | Type   | Description                                           | Required |
+| ---                 | ---    | ---                                                   | ---   |
+| `manifest_yaml`     | string | Absolute path to the manifest yaml for the deployment | True  |
+| `model`             | object | Juju model attributes                                 | True  |
+| `cloud_integration` | bool   | Enablement of a cloud integration                     | False |
+
+### Model Input:
+Juju Model resource definition borrows its schema from [Juju Model Resource].
+
+The schema requires only:
+- **name**: Name of the model
+- **cloud**: Cloud name
+
+Default fields are:
+- **region**: Region name (optional)
+- **config**: Configuration map (optional)
+- **constraints**: Constraints string (optional)
+- **credential**: Credential name (optional)
+
 
 ## Outputs
 TODO
@@ -30,29 +43,32 @@ TODO
 
 Add the following to your main.tf for the canonical k8s solution:
 
-```
+```hcl
 module "k8s" {
   source        = "git::https://github.com/canonical/k8s-bundles//terraform?ref=main" 
-  model         = "my-canonical-k8s"
+  model         = {
+    name = "my-canonical-k8s"
+    cloud = "openstack"
+  }
   manifest_yaml = "/path/to/manifest.yaml"
 }
 ```
 
-Define your manifest.yaml based on the requirements for your deployment. Specific configuration
-options can be found under the charm URLs linked above.
+Define your manifest.yaml based on the requirements for your deployment. Specific configuration options can be found under the charm URLs linked above.
 
-```
+```yaml
 k8s:
-    units: 2
+    units: 3
     base: ubuntu@24.04
     constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
-    channel: 1.31/beta
+    channel: 1.32/stable
 k8s_worker:
     units: 2
     base: ubuntu@24.04
     constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
-    channel: 1.31/beta
+    channel: 1.32/stable
 ```
 
-
-
+<!--LINKS -->
+[Juju Model Resource]: https://registry.terraform.io/providers/juju/juju/0.16.0/docs/resources/model
+[private-details]: https://git.launchpad.net/canonical-terraform-modules/tree/services/compute/canonical_k8s_cluster/main.tf#n214

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -41,7 +41,20 @@ TODO
 
 ## Usage
 
-Add the following to your main.tf for the canonical k8s solution:
+---
+**NOTE**
+
+If the model exists already, it must be imported into the model state to
+prevent the model from being destroyed and recreated.
+
+```sh
+terraform import module.k8s.juju_model.this "<name of the model>"
+```
+---
+
+
+Add the following to your `main.tf` for the canonical k8s solution:
+
 
 ```hcl
 module "k8s" {
@@ -68,6 +81,18 @@ k8s_worker:
   base: ubuntu@24.04
   constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
   channel: 1.32/stable
+```
+
+Run a plan to ensure everything look correct:
+
+```sh
+terraform plan
+```
+
+And apply with:
+
+```sh
+terraform apply
 ```
 
 <!--LINKS -->

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -48,8 +48,9 @@ module "k8s" {
   source        = "git::https://github.com/canonical/k8s-bundles//terraform?ref=main" 
   model         = {
     name = "my-canonical-k8s"
-    cloud = "openstack"
+    cloud = "prod-example-openstack"
   }
+  cloud_integration = "openstack"
   manifest_yaml = "/path/to/manifest.yaml"
 }
 ```
@@ -58,15 +59,15 @@ Define your manifest.yaml based on the requirements for your deployment. Specifi
 
 ```yaml
 k8s:
-    units: 3
-    base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
-    channel: 1.32/stable
+  units: 3
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
+  channel: 1.32/stable
 k8s_worker:
-    units: 2
-    base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
-    channel: 1.32/stable
+  units: 2
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
+  channel: 1.32/stable
 ```
 
 <!--LINKS -->

--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -47,10 +47,11 @@ module "openstack" {
 }
 
 module "ceph" {
-  count         = var.csi_integration == "ceph" ? 1 : 0
+  count         = length([for v in var.csi_integration : v if v == "ceph"])
   source        = "./ceph"
   model         = resource.juju_model.this.name
   manifest_yaml = var.manifest_yaml
+  index         = count.index
   k8s = {
     app_name = module.k8s.app_name
     config   = module.k8s_config.config

--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 module "k8s" {
-  source   = "git::https://github.com/canonical/k8s-operator//charms/worker/k8s/terraform?ref=main"
+  source   = "git::https://github.com/canonical/k8s-operator//charms/worker/k8s/terraform?ref=KU-2727/float-terraform-juju-provider"
   app_name = module.k8s_config.config.app_name
   channel  = module.k8s_config.config.channel
   # This currently just sets the bootstrap-node-taints to have the right no schedule value
@@ -13,7 +13,7 @@ module "k8s" {
                   {"bootstrap-node-taints": "node-role.kubernetes.io/control-plane:NoSchedule"}
                 )
   constraints = module.k8s_config.config.constraints
-  model       = var.model
+  model       = resource.juju_model.this.name
   resources   = module.k8s_config.config.resources
   revision    = module.k8s_config.config.revision
   base        = module.k8s_config.config.base
@@ -21,13 +21,13 @@ module "k8s" {
 }
 
 module "k8s_worker" {
-  source      = "git::https://github.com/canonical/k8s-operator//charms/worker/terraform?ref=main"
+  source      = "git::https://github.com/canonical/k8s-operator//charms/worker/terraform?ref=KU-2727/float-terraform-juju-provider"
   app_name    = module.k8s_worker_config.config.app_name
   base        = coalesce(module.k8s_worker_config.config.base,        module.k8s_config.config.base)
   constraints = coalesce(module.k8s_worker_config.config.constraints, module.k8s_config.config.constraints)
   channel     = coalesce(module.k8s_worker_config.config.channel,     module.k8s_config.config.channel)
   config      = module.k8s_worker_config.config.config
-  model       = var.model
+  model       = resource.juju_model.this.name
   resources   = module.k8s_worker_config.config.resources
   revision    = module.k8s_worker_config.config.revision
   units       = module.k8s_worker_config.config.units
@@ -36,7 +36,7 @@ module "k8s_worker" {
 module "openstack" {
   count         = var.cloud_integration == "openstack" ? 1 : 0
   source        = "./openstack"
-  model         = var.model
+  model         = resource.juju_model.this.name
   manifest_yaml = var.manifest_yaml
   k8s = {
     app_name = module.k8s.app_name

--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -49,7 +49,7 @@ module "openstack" {
 module "ceph" {
   count         = var.csi_integration == "ceph" ? 1 : 0
   source        = "./ceph"
-  model         = var.model
+  model         = resource.juju_model.this.name
   manifest_yaml = var.manifest_yaml
   k8s = {
     app_name = module.k8s.app_name

--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -2,9 +2,9 @@
 # See LICENSE file for licensing details.
 
 module "k8s" {
-  source   = "git::https://github.com/canonical/k8s-operator//charms/worker/k8s/terraform?ref=KU-2727/float-terraform-juju-provider"
-  app_name = module.k8s_config.config.app_name
-  channel  = module.k8s_config.config.channel
+  source      = "git::https://github.com/canonical/k8s-operator//charms/worker/k8s/terraform?ref=main"
+  app_name    = module.k8s_config.config.app_name
+  channel     = module.k8s_config.config.channel
   # This currently just sets the bootstrap-node-taints to have the right no schedule value
   # but more adjustments will need to be made to properly add this to bootstrap-node-taints
   # if that config value is set.
@@ -21,7 +21,7 @@ module "k8s" {
 }
 
 module "k8s_worker" {
-  source      = "git::https://github.com/canonical/k8s-operator//charms/worker/terraform?ref=KU-2727/float-terraform-juju-provider"
+  source      = "git::https://github.com/canonical/k8s-operator//charms/worker/terraform?ref=main"
   app_name    = module.k8s_worker_config.config.app_name
   base        = coalesce(module.k8s_worker_config.config.base,        module.k8s_config.config.base)
   constraints = coalesce(module.k8s_worker_config.config.constraints, module.k8s_config.config.constraints)

--- a/terraform/ceph/applications.tf
+++ b/terraform/ceph/applications.tf
@@ -5,6 +5,7 @@ module "ceph_mon" {
   source = "git::https://github.com/canonical/ceph-charms//ceph-mon/terraform?ref=main"
 
   model       = var.model
+  app_name    = module.ceph_mon_config.config.app_name
   base        = coalesce(module.ceph_mon_config.config.base, var.k8s.config.base)
   constraints = coalesce(module.ceph_mon_config.config.constraints, var.k8s.config.constraints)
   channel     = coalesce(module.ceph_mon_config.config.channel, var.k8s.config.channel)
@@ -19,6 +20,7 @@ module "ceph_osd" {
   source = "git::https://github.com/canonical/ceph-charms//ceph-osd/terraform?ref=main"
 
   model       = var.model
+  app_name    = module.ceph_osd_config.config.app_name
   base        = coalesce(module.ceph_osd_config.config.base, var.k8s.config.base)
   constraints = coalesce(module.ceph_osd_config.config.constraints, var.k8s.config.constraints)
   channel     = coalesce(module.ceph_osd_config.config.channel, var.k8s.config.channel)
@@ -36,9 +38,9 @@ module "ceph_csi" {
   model    = var.model
   app_name = module.ceph_csi_config.config.app_name
   base     = module.ceph_csi_config.config.base
+  constraints = module.ceph_csi_config.config.constraints
   channel  = coalesce(module.ceph_csi_config.config.channel, var.k8s.config.channel)
 
   config      = coalesce(module.ceph_csi_config.config.config, {})
   revision    = module.ceph_csi_config.config.revision
-  constraints = module.ceph_csi_config.config.constraints
 }

--- a/terraform/ceph/configs.tf
+++ b/terraform/ceph/configs.tf
@@ -4,17 +4,17 @@
 module "ceph_mon_config" {
   source   = "../manifest/"
   manifest = var.manifest_yaml
-  app      = "ceph_mon"
+  app      = "ceph_mon-${var.index}"
 }
 
 module "ceph_osd_config" {
   source   = "../manifest/"
   manifest = var.manifest_yaml
-  app      = "ceph_osd"
+  app      = "ceph_osd-${var.index}"
 }
 
 module "ceph_csi_config" {
   source   = "../manifest/"
   manifest = var.manifest_yaml
-  app      = "ceph_csi"
+  app      = "ceph_csi-${var.index}"
 }

--- a/terraform/ceph/configs.tf
+++ b/terraform/ceph/configs.tf
@@ -2,19 +2,19 @@
 # See LICENSE file for licensing details.
 
 module "ceph_mon_config" {
-  source   = "../manifest"
+  source   = "../manifest/"
   manifest = var.manifest_yaml
   app      = "ceph_mon"
 }
 
 module "ceph_osd_config" {
-  source   = "../manifest"
+  source   = "../manifest/"
   manifest = var.manifest_yaml
   app      = "ceph_osd"
 }
 
 module "ceph_csi_config" {
-  source   = "../manifest"
+  source   = "../manifest/"
   manifest = var.manifest_yaml
   app      = "ceph_csi"
 }

--- a/terraform/ceph/variables.tf
+++ b/terraform/ceph/variables.tf
@@ -11,6 +11,11 @@ variable "model" {
   type        = string
 }
 
+variable "index" {
+  description = "Index of the ceph-applications"
+  type        = number
+}
+
 variable "k8s" {
   description = "K8s application object"
   type = object({

--- a/terraform/ceph/versions.tf
+++ b/terraform/ceph/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }

--- a/terraform/configs.tf
+++ b/terraform/configs.tf
@@ -2,13 +2,13 @@
 # See LICENSE file for licensing details.
 
 module "k8s_config" {
-  source = "./manifest"
+  source = "./manifest/"
   manifest = var.manifest_yaml
   app = "k8s"
 }
 
 module "k8s_worker_config" {
-  source = "./manifest"
+  source = "./manifest/"
   manifest = var.manifest_yaml
   app = "k8s_worker"
 }

--- a/terraform/integrations.tf
+++ b/terraform/integrations.tf
@@ -1,8 +1,26 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+resource "juju_model" "this" {
+  name = var.model
+
+  cloud {
+    name     = var.cloud
+    region   = var.region
+  }
+
+  config = {
+    fan-config = ""
+    container-networking-method = "local"
+  }
+  provisioner "local-exec" {
+    # workaround for https://github.com/juju/terraform-provider-juju/issues/667
+    command = "juju model-config fan-config=''"
+  }
+}
+
 resource "juju_integration" "k8s_cluster_integration" {
-  model = var.model
+  model = resource.juju_model.this.name
   application {
     name      = module.k8s.app_name
     endpoint  = module.k8s.provides.k8s_cluster
@@ -14,7 +32,7 @@ resource "juju_integration" "k8s_cluster_integration" {
 }
 
 resource "juju_integration" "k8s_containerd" {
-  model = var.model
+  model = resource.juju_model.this.name
   application {
     name      = module.k8s.app_name
     endpoint  = module.k8s.provides.containerd
@@ -26,7 +44,7 @@ resource "juju_integration" "k8s_containerd" {
 }
 
 resource "juju_integration" "k8s_cos_worker_tokens" {
-  model = var.model
+  model = resource.juju_model.this.name
   application {
     name      = module.k8s.app_name
     endpoint  = module.k8s.provides.cos_worker_tokens

--- a/terraform/integrations.tf
+++ b/terraform/integrations.tf
@@ -10,11 +10,17 @@ resource "juju_model" "this" {
   }
 
   config = merge(
-    {  # Remove two keys from the config map if they exist
+  # Here we drop 2 model-config options the user may naively set
+  #   fan-config
+  #   container-networking-method
+    {
       for k, v in var.model.config != null ? var.model.config : {} :
         k => v
           if !contains(["fan-config", "container-networking-method"], k)
     },
+  # Then we merge in the required settings
+  #   fan-config                   - required to be empty for k8s
+  #   container-networking-method  - required to be local for k8s
     {
       fan-config                  = ""
       container-networking-method = "local"

--- a/terraform/manifest/outputs.tf
+++ b/terraform/manifest/outputs.tf
@@ -8,7 +8,7 @@ output "config" {
     channel     = lookup(local.yaml_data, "channel", null)
     config      = lookup(local.yaml_data, "config", null)
     constraints = lookup(local.yaml_data, "constraints", null)
-    resources   = lookup(local.yaml_data, "resoruces", null)
+    resources   = lookup(local.yaml_data, "resources", null)
     revision    = lookup(local.yaml_data, "revision", null)
     units       = lookup(local.yaml_data, "units", null)
     storage     = lookup(local.yaml_data, "storage", null)

--- a/terraform/openstack/applications.tf
+++ b/terraform/openstack/applications.tf
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 module "openstack_integrator" {
-  source      = "git::https://github.com/charmed-kubernetes/charm-openstack-integrator//terraform?ref=main"
+  source      = "git::https://github.com/charmed-kubernetes/charm-openstack-integrator//terraform?ref=KU-2727/float-terraform-juju-provider"
 
   model       = var.model
   app_name    = module.openstack_integrator_config.config.app_name
@@ -17,7 +17,7 @@ module "openstack_integrator" {
 }
 
 module "cinder_csi" {
-  source      = "git::https://github.com/canonical/cinder-csi-operator//terraform?ref=main"
+  source      = "git::https://github.com/canonical/cinder-csi-operator//terraform?ref=KU-2727/float-terraform-juju-provider"
 
   model       = var.model
   app_name    = module.cinder_csi_config.config.app_name
@@ -29,7 +29,7 @@ module "cinder_csi" {
 }
 
 module "openstack_cloud_controller" {
-  source      = "git::https://github.com/charmed-kubernetes/openstack-cloud-controller-operator//terraform?ref=main"
+  source      = "git::https://github.com/charmed-kubernetes/openstack-cloud-controller-operator//terraform?ref=KU-2727/float-terraform-juju-provider"
 
   model       = var.model
   app_name    = module.openstack_cloud_controller_config.config.app_name

--- a/terraform/openstack/applications.tf
+++ b/terraform/openstack/applications.tf
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 module "openstack_integrator" {
-  source      = "git::https://github.com/charmed-kubernetes/charm-openstack-integrator//terraform?ref=KU-2727/float-terraform-juju-provider"
+  source      = "git::https://github.com/charmed-kubernetes/charm-openstack-integrator//terraform?ref=main"
 
   model       = var.model
   app_name    = module.openstack_integrator_config.config.app_name
@@ -17,7 +17,7 @@ module "openstack_integrator" {
 }
 
 module "cinder_csi" {
-  source      = "git::https://github.com/canonical/cinder-csi-operator//terraform?ref=KU-2727/float-terraform-juju-provider"
+  source      = "git::https://github.com/canonical/cinder-csi-operator//terraform?ref=main"
 
   model       = var.model
   app_name    = module.cinder_csi_config.config.app_name
@@ -29,7 +29,7 @@ module "cinder_csi" {
 }
 
 module "openstack_cloud_controller" {
-  source      = "git::https://github.com/charmed-kubernetes/openstack-cloud-controller-operator//terraform?ref=KU-2727/float-terraform-juju-provider"
+  source      = "git::https://github.com/charmed-kubernetes/openstack-cloud-controller-operator//terraform?ref=main"
 
   model       = var.model
   app_name    = module.openstack_cloud_controller_config.config.app_name

--- a/terraform/openstack/configs.tf
+++ b/terraform/openstack/configs.tf
@@ -2,13 +2,13 @@
 # See LICENSE file for licensing details.
 
 module "openstack_integrator_config" {
-  source = "../manifest"
+  source = "../manifest/"
   manifest = var.manifest_yaml
   app = "openstack_integrator"
 }
 
 module "cinder_csi_config" {
-  source = "../manifest"
+  source = "../manifest/"
   manifest = var.manifest_yaml
   app = "cinder_csi"
 }

--- a/terraform/openstack/versions.tf
+++ b/terraform/openstack/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }

--- a/terraform/test/ceph.yaml
+++ b/terraform/test/ceph.yaml
@@ -1,29 +1,27 @@
 k8s:
-    units: 3
-    base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
-    channel: latest/edge
+  units: 3
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+  channel: latest/edge
 k8s_worker:
-    units: 3
-    base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
-    channel: latest/edge
+  units: 3
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+  channel: latest/edge
 ceph_csi:
-    channel: 1.32/stable
-    base: ubuntu@22.04
-ceph-mon:
-    channel: quincy/stable
-    constraints: cores=2 mem=4G root-disk=16G
-    num_units: 1
-    config:
-        monitor-count: 1
-        expected-osd-count: 2
-ceph-osd:
-    channel: quincy/stable
-    constraints: cores=2 mem=4G root-disk=16G
-    num_units: 2
-    storage:
-        [
-            { type: "osd-devices", count: 1, size: "1G" },
-            { type: "osd-journals", count: 1, size: "1G" },
-        ]
+  channel: 1.32/stable
+  base: ubuntu@22.04
+ceph_mon:
+  channel: quincy/stable
+  constraints: cores=2 mem=4G root-disk=16G
+  num_units: 1
+  config:
+    monitor-count: 1
+    expected-osd-count: 2
+ceph_osd:
+  channel: quincy/stable
+  constraints: cores=2 mem=4G root-disk=16G
+  num_units: 2
+  storage:
+    osd-devices: 1G,1
+    osd-journals: 1G,1

--- a/terraform/test/ceph.yaml
+++ b/terraform/test/ceph.yaml
@@ -1,27 +1,54 @@
 k8s:
   units: 3
-  base: ubuntu@24.04
-  constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+  base: ubuntu@22.04
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
   channel: latest/edge
 k8s_worker:
   units: 3
-  base: ubuntu@24.04
-  constraints: arch=amd64 cores=2 mem=8G root-disk=16G
-  channel: latest/edge
-ceph_csi:
-  channel: 1.32/stable
   base: ubuntu@22.04
-ceph_mon:
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
+  channel: latest/edge
+ceph_csi-0:
+  app_name: ceph-csi
+  channel: latest/edge
+  base: ubuntu@22.04
+ceph_mon-0:
+  app_name: ceph-mon
   channel: quincy/stable
-  constraints: cores=2 mem=4G root-disk=16G
-  num_units: 1
+  base: ubuntu@22.04
+  constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
+  units: 1
   config:
     monitor-count: 1
     expected-osd-count: 2
-ceph_osd:
+ceph_osd-0:
+  app_name: ceph-osd
   channel: quincy/stable
-  constraints: cores=2 mem=4G root-disk=16G
-  num_units: 2
+  base: ubuntu@22.04
+  constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
+  units: 2
+  storage:
+    osd-devices: 1G,1
+    osd-journals: 1G,1
+ceph_csi-1:
+  app_name: ceph-csi-alt
+  channel: latest/edge
+  base: ubuntu@22.04
+ceph_mon-1:
+  app_name: ceph-mon-alt
+  channel: quincy/stable
+  base: ubuntu@22.04
+  constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
+  units: 1
+  config:
+    monitor-count: 1
+    expected-osd-count: 2
+ceph_osd-1:
+  app_name: ceph-osd-alt
+  channel: quincy/stable
+  base: ubuntu@22.04
+  constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
+  units: 2
   storage:
     osd-devices: 1G,1
     osd-journals: 1G,1

--- a/terraform/test/openstack.yaml
+++ b/terraform/test/openstack.yaml
@@ -1,15 +1,15 @@
 k8s:
-    units: 3
-    base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
-    channel: latest/edge
+  units: 3
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
+  channel: latest/edge
 k8s_worker:
-    units: 3
-    base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
-    channel: latest/edge
+  units: 3
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
+  channel: latest/edge
 openstack_integrator:
-    channel: 1.31/stable
-    base: ubuntu@22.04
+  channel: 1.31/stable
+  base: ubuntu@22.04
 cinder_csi: {}
 openstack_cloud_controller: {}

--- a/terraform/test/test.tf
+++ b/terraform/test/test.tf
@@ -7,10 +7,16 @@ module "k8s" {
   }
   cloud_integration = var.cloud_integration
   manifest_yaml = var.manifest_yaml
+  csi_integration = var.csi_integration
 }
 
 variable "cloud_integration" {
   description = "Selection of a cloud integration."
+  type        = string
+}
+
+variable "csi_integration" {
+  description = "Selection of a csi integration."
   type        = string
 }
 

--- a/terraform/test/test.tf
+++ b/terraform/test/test.tf
@@ -1,8 +1,8 @@
 module "k8s" {
-  source        = "git::https://github.com/canonical/k8s-bundles//terraform?ref=main" 
+  source        = "git::https://github.com/canonical/k8s-bundles//terraform?ref=main"
   model         = {
     name   = "my-canonical-k8s"
-    cloud  = "prod-k8s-openstack"
+    cloud  = "my-prod-cloud"
     config = {"test": true}
   }
   cloud_integration = var.cloud_integration
@@ -17,7 +17,7 @@ variable "cloud_integration" {
 
 variable "csi_integration" {
   description = "Selection of a csi integration."
-  type        = string
+  type        = list(string)
 }
 
 variable "manifest_yaml" {

--- a/terraform/test/test.tf
+++ b/terraform/test/test.tf
@@ -1,0 +1,20 @@
+module "k8s" {
+  source        = "git::https://github.com/canonical/k8s-bundles//terraform?ref=main" 
+  model         = {
+    name   = "my-canonical-k8s"
+    cloud  = "prod-k8s-openstack"
+    config = {"test": true}
+  }
+  cloud_integration = var.cloud_integration
+  manifest_yaml = var.manifest_yaml
+}
+
+variable "cloud_integration" {
+  description = "Selection of a cloud integration."
+  type        = string
+}
+
+variable "manifest_yaml" {
+  description = "Absolute path to the manifest yaml file for the charm configurations."
+  type        = string
+}

--- a/terraform/test/vanilla.yaml
+++ b/terraform/test/vanilla.yaml
@@ -1,10 +1,10 @@
 k8s:
-    units: 3
-    base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
-    channel: latest/edge
+  units: 3
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
+  channel: latest/edge
 k8s_worker:
-    units: 3
-    base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
-    channel: latest/edge
+  units: 3
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
+  channel: latest/edge

--- a/terraform/test/vanilla.yaml
+++ b/terraform/test/vanilla.yaml
@@ -1,10 +1,10 @@
 k8s:
     units: 3
     base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
     channel: latest/edge
 k8s_worker:
     units: 3
     base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
     channel: latest/edge

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -57,7 +57,7 @@ EOT
   validation {
     condition = (
       var.model.config == null || alltrue([
-        for k, v in var.model.config:
+        for k, v in var.model.config != null ? var.model.config : {}:
         v == null || can(tostring(v)) || can(tonumber(v)) || can(tobool(v))
       ])
     )

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,13 +20,15 @@ variable "cloud_integration" {
 
 variable "csi_integration" {
   description = "Selection of a csi integration"
-  type        = string
-  default     = ""
+  type        = list(string)
+  default     = []
   nullable    = false
 
   validation {
-    condition = can(regex("^(|ceph)$", var.csi_integration))
-    error_message = "CSI must be one of '', or 'ceph'"
+    condition = alltrue([
+      for v in var.csi_integration : can(regex("^(|ceph)$", v))
+    ])
+    error_message = "Each item in 'csi_integration' must be either '' or 'ceph'."
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,10 +22,10 @@ variable "csi_integration" {
   description = "Selection of a csi integration"
   type        = string
   default     = ""
-  nullable = false
+  nullable    = false
 
   validation {
-    condition     = contains(["", "ceph"], var.csi_integration)
+    condition = can(regex("^(|ceph)$", var.csi_integration))
     error_message = "CSI must be one of '', or 'ceph'"
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,14 +7,14 @@ variable "manifest_yaml" {
 }
 
 variable "cloud_integration" {
-  description = "Selection of a cloud integration"
+  description = "Selection of a cloud integration."
   type        = string
   default     = ""
-  nullable = false
+  nullable    = false
 
   validation {
-    condition     = contains(["", "openstack"], var.cloud_integration)
-    error_message = "Cloud must be one of '', or 'openstack'"
+    condition = can(regex("^(|openstack)$", var.cloud_integration))
+    error_message = "Cloud integration must be one of: '', openstack."
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,11 +6,6 @@ variable "manifest_yaml" {
   type        = string
 }
 
-variable "model" {
-  description = "Name of the Juju model to deploy to."
-  type        = string
-}
-
 variable "cloud_integration" {
   description = "Selection of a cloud integration"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,3 +29,38 @@ variable "csi_integration" {
     error_message = "CSI must be one of '', or 'ceph'"
   }
 }
+
+variable "model" {
+  description = <<EOT
+Juju Model resource definition.
+
+Schema represented by the juju model resource:
+  - name: Name of the model
+  - cloud: Cloud name
+  - region: Region name (optional)
+  - config: Configuration map (optional)
+  - constraints: Constraints string (optional)
+  - credential: Credential name (optional)
+
+https://registry.terraform.io/providers/juju/juju/0.16.0/docs/resources/model
+EOT
+
+  type        = object({
+    name         = string
+    cloud        = string
+    region       = optional(string)
+    config       = optional(map(any))
+    constraints  = optional(string)
+    credential   = optional(string)
+  })
+
+  validation {
+    condition = (
+      var.model.config == null || alltrue([
+        for k, v in var.model.config:
+        v == null || can(tostring(v)) || can(tonumber(v)) || can(tobool(v))
+      ])
+    )
+    error_message = "Config must be a map where values are only strings, numbers, or bools."
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
## BREAKING CHANGE


In order to prevent terraform users from deploying with fan networking enabled, we need to control the juju model object and explicitly prevent it from being set to enable fan networking in machine modules.  To do this, we must break the user interface of the main TF modules by adjusting the `model` configuration. 

Rather than it being the `name` of the module, it will now by a configuration structure similar to the juju-provider model resource. This lets us override the keys in the config to specify the `fan-config` and `container-networking-method`. 

This will be interruptive to existing uses of our terraform modules. 