### PR TITLE
Wait for juju to create the model before forcing the fan-config

### DIFF
--- a/terraform/integrations.tf
+++ b/terraform/integrations.tf
@@ -32,7 +32,15 @@ resource "juju_model" "this" {
 
   provisioner "local-exec" {
     # workaround for https://github.com/juju/terraform-provider-juju/issues/667
-    command = "juju model-config fan-config=''"
+    command = <<EOT
+    timeout 30s bash -c "
+      until juju model-config -m ${var.model.name} fan-config='' 2>/dev/null; do
+        echo \"Wait to set fan-config to empty on model=${var.model.name}\"
+        sleep 1
+      done
+    " || echo "ERROR: Timeout reached while waiting for fan-config update!" >&2
+    EOT
+    interpreter = ["bash", "-c"]
   }
 }
 


### PR DESCRIPTION
Overcome this issue:

If the model isn't the "current-selected-model", then juju cannot appropriately set the fan-config
If the model is newly created, it make not show up immediately, so retry for 30s until juju recognized the model


```
│ Error: local-exec provisioner error
│ 
│   with module.k8s.juju_model.this,
│   on .terraform/modules/k8s/terraform/integrations.tf line 33, in resource "juju_model" "this":
│   33:   provisioner "local-exec" {
│ 
│ Error running command 'juju model-config fan-config=''': exit status 2.
│ Output: ERROR No selected model.
│ 
│ Only the controller model exists. Use "juju add-model" to create an initial
│ model.
│ 
│ 
```