### PR TITLE
Backport TF submodule adjustments from #25

### DIFF
--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -34,14 +34,16 @@ module "k8s_worker" {
 }
 
 module "openstack" {
-  count           = var.cloud_integration == "openstack" ? 1 : 0
-  source          = "./openstack"
-  model           = var.model
-  manifest_yaml   = var.manifest_yaml
-  k8s             = {
-    app_name   = module.k8s.app_name
-    config     = module.k8s_config.config
-    provides   = module.k8s.provides
-    requires   = module.k8s.requires
+  count         = var.cloud_integration == "openstack" ? 1 : 0
+  source        = "./openstack"
+  model         = var.model
+  manifest_yaml = var.manifest_yaml
+  k8s           = {
+    app_name    = module.k8s.app_name
+    base        = module.k8s_config.config.base
+    constraints = module.k8s_config.config.constraints
+    channel     = module.k8s_config.config.channel
+    provides    = module.k8s.provides
+    requires    = module.k8s.requires
   }
 }

--- a/terraform/openstack/applications.tf
+++ b/terraform/openstack/applications.tf
@@ -6,9 +6,9 @@ module "openstack_integrator" {
 
   model       = var.model
   app_name    = module.openstack_integrator_config.config.app_name
-  base        = coalesce(module.openstack_integrator_config.config.base, var.k8s.config.base)
-  constraints = coalesce(module.openstack_integrator_config.config.constraints, var.k8s.config.constraints)
-  channel     = coalesce(module.openstack_integrator_config.config.channel, var.k8s.config.channel)
+  base        = coalesce(module.openstack_integrator_config.config.base, var.k8s.base)
+  constraints = coalesce(module.openstack_integrator_config.config.constraints, var.k8s.constraints)
+  channel     = coalesce(module.openstack_integrator_config.config.channel, var.k8s.channel)
 
   config      = coalesce(module.openstack_integrator_config.config.config, {})
   resources   = module.openstack_integrator_config.config.resources
@@ -21,8 +21,8 @@ module "cinder_csi" {
 
   model       = var.model
   app_name    = module.cinder_csi_config.config.app_name
-  base        = coalesce(module.cinder_csi_config.config.base,        module.openstack_integrator_config.config.base,        var.k8s.config.base)
-  channel     = coalesce(module.cinder_csi_config.config.channel,     module.openstack_integrator_config.config.channel,     var.k8s.config.channel)
+  base        = coalesce(module.cinder_csi_config.config.base,        module.openstack_integrator_config.config.base,        var.k8s.base)
+  channel     = coalesce(module.cinder_csi_config.config.channel,     module.openstack_integrator_config.config.channel,     var.k8s.channel)
 
   config      = coalesce(module.cinder_csi_config.config.config, {})
   revision    = module.cinder_csi_config.config.revision
@@ -33,8 +33,8 @@ module "openstack_cloud_controller" {
 
   model       = var.model
   app_name    = module.openstack_cloud_controller_config.config.app_name
-  base        = coalesce(module.openstack_cloud_controller_config.config.base,        module.openstack_integrator_config.config.base,        var.k8s.config.base)
-  channel     = coalesce(module.openstack_cloud_controller_config.config.channel,     module.openstack_integrator_config.config.channel,     var.k8s.config.channel)
+  base        = coalesce(module.openstack_cloud_controller_config.config.base,        module.openstack_integrator_config.config.base,        var.k8s.base)
+  channel     = coalesce(module.openstack_cloud_controller_config.config.channel,     module.openstack_integrator_config.config.channel,     var.k8s.channel)
 
   config      = coalesce(module.openstack_cloud_controller_config.config.config, {})
   revision    = module.openstack_cloud_controller_config.config.revision

--- a/terraform/openstack/variables.tf
+++ b/terraform/openstack/variables.tf
@@ -14,9 +14,11 @@ variable "model" {
 variable "k8s" {
   description = "K8s application object"
   type        = object({
-    app_name  = string
-    config    = map(string)
-    provides  = map(string)
-    requires  = map(string)
+    app_name    = string
+    base        = string
+    constraints = string
+    channel     = string
+    provides    = map(string)
+    requires    = map(string)
   })
 }

--- a/terraform/test/openstack.yaml
+++ b/terraform/test/openstack.yaml
@@ -3,15 +3,18 @@ k8s:
     base: ubuntu@24.04
     constraints: arch=amd64 cores=2 mem=8G root-disk=16G
     channel: 1.32/stable
+    config: {}
 k8s_worker:
     units: 3
     base: ubuntu@24.04
     constraints: arch=amd64 cores=2 mem=8G root-disk=16G
     channel: 1.32/stable
+    config: {}
 openstack_integrator:
-    channel: 1.32/beta
+    channel: 1.32/stable
     base: ubuntu@22.04
+    config: {}
 cinder_csi:
-    channel: 1.32/beta
+    channel: 1.32/stable
 openstack_cloud_controller:
-    channel: 1.32/beta
+    channel: 1.32/stable


### PR DESCRIPTION
### Overview
Enables passing k8s config when using openstack integration

### Details
* Backports concepts of #25
* Now that 1.32 is released, lets use the released versions of the openstack integratoin stack in the examples
    * cinder-csi
    * openstack-integrator
    * openstack-cloud-controller