### PR TITLE
Integrate AWS cloud integrations with k8s and k8s-worker applications

### DIFF
--- a/terraform-test/manifest-aws.yaml
+++ b/terraform-test/manifest-aws.yaml
@@ -1,15 +1,15 @@
 k8s:
   units: 3
   base: ubuntu@24.04
-  constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
   channel: latest/edge
 k8s-worker:
   units: 3
   base: ubuntu@24.04
-  constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
   channel: latest/edge
 aws-integrator:
-  channel: 1.32/stable
+  channel: latest/edge
   base: ubuntu@24.04
 aws-k8s-storage: {}
 aws-cloud-provider: {}

--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -90,6 +90,12 @@ module "aws" {
     provides    = module.k8s.provides
     requires    = module.k8s.requires
   }
+  k8s_worker = {
+    for k, m in module.k8s_worker : k => {
+      app_name  = m.app_name
+      requires  = m.requires
+    }
+  }
 }
 
 module "ceph" {

--- a/terraform/aws/integrations.tf
+++ b/terraform/aws/integrations.tf
@@ -37,6 +37,31 @@ resource "juju_integration" "external_cloud_provider" {
   }
 }
 
+resource "juju_integration" "aws_integration_control_plane" {
+  model = var.model
+  application {
+    name      = module.aws_integrator.app_name
+    endpoint  = module.aws_integrator.provides.aws
+  }
+  application {
+    name      = var.k8s.app_name
+    endpoint  = var.k8s.requires.aws
+  }
+}
+
+resource "juju_integration" "aws_integration_worker" {
+  model = var.model
+  for_each = var.k8s_worker
+  application {
+    name      = module.aws_integrator.app_name
+    endpoint  = module.aws_integrator.provides.aws
+  }
+  application {
+    name      = each.value.app_name
+    endpoint  = each.value.requires.aws
+  }
+}
+
 resource "juju_integration" "aws_cloud_provider_kube_control" {
   model = var.model
   application {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -22,3 +22,11 @@ variable "k8s" {
     requires    = map(string)
   })
 }
+
+variable "k8s_worker" {
+  description = "K8s worker application object"
+  type = map(object({
+    app_name    = string
+    requires    = map(string)
+  }))
+}


### PR DESCRIPTION
### Overview
* Actually testing a valid deployment on AWS with cloud integrations

### Details
* adjust constraints to use juju_provider values in `MB` rather than `GB`
* adjust aws-integrator example to use latest/edge
* create the integration for `k8s:aws aws-integrator:aws`
* create the integrations for `k8s-worker:aws aws-integrator:aws` for each worker application