### PR TITLE
[Backport 1.33] AWS Integration 

### DIFF
--- a/.github/workflows/plan-terraform.yaml
+++ b/.github/workflows/plan-terraform.yaml
@@ -17,6 +17,10 @@ jobs:
     strategy:
       matrix:
         test:
+        - name: AWS
+          yaml: ./manifest-aws.yaml
+          cloud_integration: aws
+          csi_integration: '[]'
         - name: Vanilla
           yaml: ./manifest-vanilla.yaml
           cloud_integration: ''

--- a/terraform-test/manifest-aws.yaml
+++ b/terraform-test/manifest-aws.yaml
@@ -1,0 +1,15 @@
+k8s:
+  units: 3
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+  channel: latest/edge
+k8s-worker:
+  units: 3
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+  channel: latest/edge
+aws-integrator:
+  channel: 1.32/stable
+  base: ubuntu@24.04
+aws-k8s-storage: {}
+aws-cloud-provider: {}

--- a/terraform-test/manifest-aws.yaml
+++ b/terraform-test/manifest-aws.yaml
@@ -1,15 +1,15 @@
 k8s:
   units: 3
   base: ubuntu@24.04
-  constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
   channel: latest/edge
 k8s-worker:
   units: 3
   base: ubuntu@24.04
-  constraints: arch=amd64 cores=2 mem=8G root-disk=16G
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
   channel: latest/edge
 aws-integrator:
-  channel: 1.32/stable
+  channel: latest/edge
   base: ubuntu@24.04
 aws-k8s-storage: {}
 aws-cloud-provider: {}

--- a/terraform-test/manifest-aws.yaml
+++ b/terraform-test/manifest-aws.yaml
@@ -2,14 +2,16 @@ k8s:
   units: 3
   base: ubuntu@24.04
   constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
-  channel: latest/edge
+  channel: 1.33/stable
 k8s-worker:
   units: 3
   base: ubuntu@24.04
   constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
-  channel: latest/edge
+  channel: 1.33/stable
 aws-integrator:
-  channel: latest/edge
+  channel: 1.33/stable
   base: ubuntu@24.04
-aws-k8s-storage: {}
-aws-cloud-provider: {}
+aws-k8s-storage:
+  channel: 1.33/stable
+aws-cloud-provider:
+  channel: 1.33/stable

--- a/terraform-test/manifest-ceph.yaml
+++ b/terraform-test/manifest-ceph.yaml
@@ -8,7 +8,7 @@ k8s:
 ceph-csi:
   csi_integration: ceph
   cluster-name: main
-  channel: latest/edge
+  channel: 1.33/stable
   base: ubuntu@22.04
 ceph-mon:
   csi_integration: ceph
@@ -35,7 +35,7 @@ ceph-csi-alt:
   csi_integration: ceph
   cluster-name: alt
   charm: ceph-csi
-  channel: latest/edge
+  channel: 1.33/stable
   base: ubuntu@22.04
 ceph_mon-alt:
   csi_integration: ceph

--- a/terraform-test/manifest-openstack.yaml
+++ b/terraform-test/manifest-openstack.yaml
@@ -11,7 +11,11 @@ k8s-worker:
   channel: 1.33/stable
   config: {}
 openstack-integrator:
-  channel: latest/stable
-  base: ubuntu@22.04
-cinder-csi: {}
-openstack-cloud-controller: {}
+  channel: 1.33/stable
+  base: ubuntu@24.04
+cinder-csi:
+  channel: 1.33/stable
+  base: ubuntu@24.04
+openstack-cloud-controller:
+  channel: 1.33/stable
+  base: ubuntu@24.04

--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -77,6 +77,21 @@ module "openstack" {
   }
 }
 
+module "aws" {
+  count           = var.cloud_integration == "aws" ? 1 : 0
+  source          = "./aws"
+  model           = resource.juju_model.this.name
+  manifest_yaml   = var.manifest_yaml
+  k8s             = {
+    app_name    = module.k8s.app_name
+    base        = local.k8s_config.base
+    constraints = local.k8s_config.constraints
+    channel     = local.k8s_config.channel
+    provides    = module.k8s.provides
+    requires    = module.k8s.requires
+  }
+}
+
 module "ceph" {
   count         = length([for v in var.csi_integration : v if v == "ceph"])
   source        = "./ceph"

--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -90,6 +90,12 @@ module "aws" {
     provides    = module.k8s.provides
     requires    = module.k8s.requires
   }
+  k8s_worker = {
+    for k, m in module.k8s_worker : k => {
+      app_name  = m.app_name
+      requires  = m.requires
+    }
+  }
 }
 
 module "ceph" {

--- a/terraform/aws/applications.tf
+++ b/terraform/aws/applications.tf
@@ -1,0 +1,88 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  _integrator_keys       = keys(module.aws_integrator_config.config)
+  _storage_keys          = keys(module.aws_k8s_storage_config.config)
+  _cloud_controller_keys = keys(module.aws_cloud_provider_config.config)
+  _max_key_count         = max(length(local._integrator_keys), length(local._storage_keys), length(local._cloud_controller_keys))
+
+  integrator_config = local._max_key_count == 1 ? module.aws_integrator_config.config[local._integrator_keys[0]] : null
+  storage = local._max_key_count == 1 ? module.aws_k8s_storage_config.config[local._storage_keys[0]] : null
+  cloud_controller_config = local._max_key_count == 1 ? module.aws_cloud_provider_config.config[local._cloud_controller_keys[0]] : null
+}
+
+resource "null_resource" "validate_all_apps_unique" {
+  count = local._max_key_count == 1 ? 0 : 1
+
+  provisioner "local-exec" {
+    command = <<EOT
+      >&2 echo "ERROR: Expected exactly 1 entry for each application"
+      >&2 echo "  aws-integrator: ${local._integrator_keys}"
+      >&2 echo "  aws-k8s-storage: ${local._storage_keys}"
+      >&2 echo "  aws-cloud-provider: ${local._cloud_controller_keys}"
+      exit 1
+    EOT
+  }
+}
+
+output "debug" {
+  value = {
+    integrator_config = local.integrator_config
+    storage_config = local.storage
+    cloud_controller_config = local.cloud_controller_config
+  }
+}
+
+module "aws_integrator" {
+  source      = "git::https://github.com/charmed-kubernetes/charm-aws-integrator//terraform?ref=main"
+
+  model       = var.model
+  app_name    = local.integrator_config.app_name
+  base        = coalesce(local.integrator_config.base, var.k8s.base)
+  constraints = coalesce(local.integrator_config.constraints, var.k8s.constraints)
+  channel     = coalesce(local.integrator_config.channel, var.k8s.channel)
+
+  config      = coalesce(local.integrator_config.config, {})
+  resources   = local.integrator_config.resources
+  revision    = local.integrator_config.revision
+  units       = local.integrator_config.units
+}
+
+module "aws_k8s_storage" {
+  source      = "git::https://github.com/charmed-kubernetes/aws-k8s-storage//terraform?ref=main"
+
+  model       = var.model
+  app_name    = local.storage.app_name
+  base        = coalesce(
+    local.storage.base,
+    local.integrator_config.base,
+    var.k8s.base
+  )
+  channel     = coalesce(
+    local.storage.channel,
+    local.integrator_config.channel,
+    var.k8s.channel
+  )
+  config      = coalesce(local.storage.config, {})
+  revision    = local.storage.revision
+}
+
+module "aws_cloud_provider" {
+  source      = "git::https://github.com/charmed-kubernetes/charm-aws-cloud-provider//terraform?ref=main"
+
+  model       = var.model
+  app_name    = local.cloud_controller_config.app_name
+  base        = coalesce(
+    local.cloud_controller_config.base,
+    local.integrator_config.base,
+    var.k8s.base
+  )
+  channel     = coalesce(
+    local.cloud_controller_config.channel,
+    local.integrator_config.channel,
+    var.k8s.channel
+  )
+  config      = coalesce(local.cloud_controller_config.config, {})
+  revision    = local.cloud_controller_config.revision
+}

--- a/terraform/aws/configs.tf
+++ b/terraform/aws/configs.tf
@@ -1,0 +1,20 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+module "aws_integrator_config" {
+  source = "../manifest/"
+  manifest = var.manifest_yaml
+  charm = "aws-integrator"
+}
+
+module "aws_k8s_storage_config" {
+  source = "../manifest/"
+  manifest = var.manifest_yaml
+  charm = "aws-k8s-storage"
+}
+
+module "aws_cloud_provider_config" {
+  source = "../manifest/"
+  manifest = var.manifest_yaml
+  charm = "aws-cloud-provider"
+}

--- a/terraform/aws/integrations.tf
+++ b/terraform/aws/integrations.tf
@@ -1,0 +1,62 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_integration" "aws_storage_client" {
+  model = var.model
+  application {
+    name      = module.aws_integrator.app_name
+    endpoint  = module.aws_integrator.provides.aws
+  }
+  application {
+    name      = module.aws_k8s_storage.app_name
+    endpoint  = module.aws_k8s_storage.requires.aws_integration
+  }
+}
+
+resource "juju_integration" "cloud_controller_aws_integrator" {
+  model = var.model
+  application {
+    name      = module.aws_integrator.app_name
+    endpoint  = module.aws_integrator.provides.aws
+  }
+  application {
+    name      = module.aws_cloud_provider.app_name
+    endpoint  = module.aws_cloud_provider.requires.aws_integration
+  }
+}
+
+resource "juju_integration" "external_cloud_provider" {
+  model = var.model
+  application {
+    name      = var.k8s.app_name
+    endpoint  = var.k8s.requires.external_cloud_provider
+  }
+  application {
+    name      = module.aws_cloud_provider.app_name
+    endpoint  = module.aws_cloud_provider.provides.external_cloud_provider
+  }
+}
+
+resource "juju_integration" "aws_cloud_provider_kube_control" {
+  model = var.model
+  application {
+    name      = var.k8s.app_name
+    endpoint  = var.k8s.provides.kube_control
+  }
+  application {
+    name      = module.aws_cloud_provider.app_name
+    endpoint  = module.aws_cloud_provider.requires.kube_control
+  }
+}
+
+resource "juju_integration" "aws_k8s_storage_kube_control" {
+  model = var.model
+  application {
+    name      = var.k8s.app_name
+    endpoint  = var.k8s.provides.kube_control
+  }
+  application {
+    name      = module.aws_k8s_storage.app_name
+    endpoint  = module.aws_k8s_storage.requires.kube_control
+  }
+}

--- a/terraform/aws/integrations.tf
+++ b/terraform/aws/integrations.tf
@@ -37,6 +37,31 @@ resource "juju_integration" "external_cloud_provider" {
   }
 }
 
+resource "juju_integration" "aws_integration_control_plane" {
+  model = var.model
+  application {
+    name      = module.aws_integrator.app_name
+    endpoint  = module.aws_integrator.provides.aws
+  }
+  application {
+    name      = var.k8s.app_name
+    endpoint  = var.k8s.requires.aws
+  }
+}
+
+resource "juju_integration" "aws_integration_worker" {
+  model = var.model
+  for_each = var.k8s_worker
+  application {
+    name      = module.aws_integrator.app_name
+    endpoint  = module.aws_integrator.provides.aws
+  }
+  application {
+    name      = each.value.app_name
+    endpoint  = each.value.requires.aws
+  }
+}
+
 resource "juju_integration" "aws_cloud_provider_kube_control" {
   model = var.model
   application {

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,0 +1,17 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "aws_integrator" {
+  description = "Object of the aws-integrator application."
+  value       = module.aws_integrator
+}
+
+output "aws_k8s_storage" {
+  description = "Object of the aws-k8s-storage application."
+  value       = module.aws_k8s_storage
+}
+
+output "aws_cloud_provider" {
+  description = "Object of the aws-cloud-provider application."
+  value       = module.aws_cloud_provider
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,24 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "manifest_yaml" {
+  description = "Absolute path to the manifest yaml file for the charm configurations."
+  type        = string
+}
+
+variable "model" {
+  description = "Name of the Juju model to deploy to."
+  type        = string
+}
+
+variable "k8s" {
+  description = "K8s application object"
+  type        = object({
+    app_name    = string
+    base        = string
+    constraints = string
+    channel     = string
+    provides    = map(string)
+    requires    = map(string)
+  })
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -22,3 +22,11 @@ variable "k8s" {
     requires    = map(string)
   })
 }
+
+variable "k8s_worker" {
+  description = "K8s worker application object"
+  type = map(object({
+    app_name    = string
+    requires    = map(string)
+  }))
+}

--- a/terraform/aws/versions.tf
+++ b/terraform/aws/versions.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.14.0, < 1.0.0"
+    }
+  }
+}

--- a/terraform/openstack/applications.tf
+++ b/terraform/openstack/applications.tf
@@ -18,9 +18,9 @@ resource "null_resource" "validate_all_apps_unique" {
   provisioner "local-exec" {
     command = <<EOT
       >&2 echo "ERROR: Expected exactly 1 entry for each application"
-      >&2 echo "  openstack_integrator: ${local._integrator_keys}"
-      >&2 echo "  cinder_csi: ${local._cinder_keys}"
-      >&2 echo "  openstack_cloud_controller: ${local._cloud_controller_keys}"
+      >&2 echo "  openstack-integrator: ${local._integrator_keys}"
+      >&2 echo "  cinder-csi: ${local._cinder_keys}"
+      >&2 echo "  openstack-cloud-controller: ${local._cloud_controller_keys}"
       exit 1
     EOT
   }
@@ -33,8 +33,6 @@ output "debug" {
     cloud_controller_config = local.cloud_controller_config
   }
 }
-
-
 
 module "openstack_integrator" {
   source      = "git::https://github.com/charmed-kubernetes/charm-openstack-integrator//terraform?ref=release_1.33"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,8 +13,8 @@ variable "cloud_integration" {
   nullable    = false
 
   validation {
-    condition = can(regex("^(|openstack)$", var.cloud_integration))
-    error_message = "Cloud integration must be one of: '', openstack."
+    condition = can(regex("^(|openstack|aws)$", var.cloud_integration))
+    error_message = "Cloud integration unsupported. Try: '', 'aws', or 'openstack'"
   }
 }
 


### PR DESCRIPTION
Backports
* #17
* #37 

### Overview
* Created Reference integration for a second cloud -- aws integration
* Actually testing a valid deployment on AWS with cloud integrations

### Details
*   adjust constraints to use juju_provider values in MB rather than GB
*   adjust aws-integrator example to use 1.33/stable
*   create the integration for k8s:aws aws-integrator:aws
*   create the integrations for k8s-worker:aws aws-integrator:aws for each worker application

